### PR TITLE
Fix double opacity bug

### DIFF
--- a/Paranormal/Paranormal/DocumentModels/Layer.swift
+++ b/Paranormal/Paranormal/DocumentModels/Layer.swift
@@ -69,7 +69,6 @@ public class Layer : NSManagedObject{
         let width = CGImageGetWidth(cgImage)
         let height = CGImageGetHeight(cgImage)
         let rect = CGRectMake(0.0, 0.0, CGFloat(width), CGFloat(height))
-
         CGContextClearRect(context, rect)
 
         CGContextDrawImage(context, rect, cgImage)
@@ -78,9 +77,9 @@ public class Layer : NSManagedObject{
     func fillWithEmpty(size: NSSize) {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGBitmapInfo(CGImageAlphaInfo.PremultipliedLast.rawValue)
-        var context = CGBitmapContextCreate(nil, 5, 5, 8, 0, colorSpace, bitmapInfo)
-        CGContextSetFillColorWithColor(context, CGColorCreateGenericRGB(0, 0, 0, 0))
-        CGContextFillRect(context, CGRectMake(0, 0, 5, 5))
+        var context = CGBitmapContextCreate(nil, UInt(size.width), UInt(size.height),
+            8, 0, colorSpace, bitmapInfo)
+        CGContextClearRect(context, CGRectMake(0, 0, size.width, size.height))
         let cgImage = CGBitmapContextCreateImage(context)
 
         let nsImage = NSImage(CGImage: cgImage, size: size)

--- a/Paranormal/Paranormal/Tools/BrushTool.swift
+++ b/Paranormal/Paranormal/Tools/BrushTool.swift
@@ -46,6 +46,11 @@ public class BrushTool : NSObject, EditorActiveTool {
         if let brushOpacity = editorViewController.brushOpacity {
             editLayer?.opacity = Float(brushOpacity)
         }
+
+        if let context = editorContext {
+            editLayer?.drawToContext(context)
+        }
+
         lastPoint = point
     }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/kotoole1%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23issuecomment-75860546%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-02-24T22%3A26%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20998bd0c7f55a3e1dec5f42ef9f5e3ff41eaba2bd%20Paranormal/Paranormal/DocumentModels/Layer.swift%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25294763%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20what%20the%20old%20or%20new%20behavior%20is%20doing%20here...%20what%27s%20the%20purpose%20of%20the%205x5%20rect%3F%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A33%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20typo%20/%20copy%20pasta.%20Basically%20don%27t%20hardcode%20to%205x5%20pixels...%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A37%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20I%20just%20read%20this%20diff%20wrong%20and%20thought%20the%205x5%20rect%20was%20still%20in%20there.%20%22%2C%20%22created_at%22%3A%20%222015-02-24T22%3A22%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/DocumentModels/Layer.swift%3AL77-86%22%7D%2C%20%22Pull%20998bd0c7f55a3e1dec5f42ef9f5e3ff41eaba2bd%20Paranormal/Paranormal/DocumentModels/Layer.swift%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25295000%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%228%20is%20bits%20per%20color%2C%20yeah%3F%20%5Cr%5CnThinking%20about%20numerical%20stuff%20from%20yesterday%2C%20I%20really%20don%27t%20think%20we%20want%20to%20move%20to%2032-bit%20colors.%20We%27re%20memory-hungry%20enough%20as%20it%20is%20with%20our%20undo%20stack.%20If%20that%20stuff%20becomes%20problematic%2C%20we%20might%20just%20want%20our%20internal%20representation%20to%20be%20in%20PD%20or%20quaternion%20form.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A36%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20thats%20an%20interesting%20idea.%20need%20some%20time%20to%20think%20about%20it.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A37%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20be%20clear%2C%20I%20don%27t%20support%20my%20idea%20unless%20these%20things%20become%20a%20huge%20problem.%20It%20was%20just%20a%20thought.%22%2C%20%22created_at%22%3A%20%222015-02-24T22%3A21%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/DocumentModels/Layer.swift%3AL77-86%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/lukemetz/Paranormal/pull/69%23issuecomment-75860546%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25294763%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25295000%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25295092%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25295132%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25299295%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/69%23discussion_r25299353%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kotoole1'><img src='https://avatars.githubusercontent.com/u/2672344?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 998bd0c7f55a3e1dec5f42ef9f5e3ff41eaba2bd Paranormal/Paranormal/DocumentModels/Layer.swift 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/69#discussion_r25294763'>File: Paranormal/Paranormal/DocumentModels/Layer.swift:L77-86</a></b>
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> I'm not sure what the old or new behavior is doing here... what's the purpose of the 5x5 rect?
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> A typo / copy pasta. Basically don't hardcode to 5x5 pixels...
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> I think I just read this diff wrong and thought the 5x5 rect was still in there.
- [ ] <a href='#crh-comment-Pull 998bd0c7f55a3e1dec5f42ef9f5e3ff41eaba2bd Paranormal/Paranormal/DocumentModels/Layer.swift 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/69#discussion_r25295000'>File: Paranormal/Paranormal/DocumentModels/Layer.swift:L77-86</a></b>
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> 8 is bits per color, yeah?
  Thinking about numerical stuff from yesterday, I really don't think we want to move to 32-bit colors. We're memory-hungry enough as it is with our undo stack. If that stuff becomes problematic, we might just want our internal representation to be in PD or quaternion form.
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> Hmm, thats an interesting idea. need some time to think about it.
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> To be clear, I don't support my idea unless these things become a huge problem. It was just a thought.

<a href='https://www.codereviewhub.com/lukemetz/Paranormal/pull/69?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/lukemetz/Paranormal/pull/69?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/lukemetz/Paranormal/pull/69?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/lukemetz/Paranormal/pull/69'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
