### PR TITLE
Using geometric slerp for more accurate interpolation

### DIFF
--- a/Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh
+++ b/Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh
@@ -1,15 +1,61 @@
 varying vec2 textureCoordinate;
-
 uniform sampler2D inputImageTexture;
 uniform sampler2D inputImageTexture2;
 uniform float opacity;
+const float normalZero = 0.5;
+const float epsilon = 0.001; // less than half 1/255
+const vec3 zUpNormal = vec3(0.0, 0.0, 1.0);
+
+float angle(vec3 a, vec3 b) {
+    return acos(dot(a, b)) / (length(a) * length (b));
+}
+
+vec3 colorToNormal(vec4 color) {
+    return vec3(2.0 * (color.r - normalZero),
+                2.0 * (color.g - normalZero),
+                2.0 * (color.b - normalZero));
+}
+
+vec4 normalToColor(vec3 normal, float alpha) {
+    return vec4((normalZero + (0.5 * normal)), alpha);
+}
+
+vec3 slerp(vec3 fromVector, vec3 toVector, float mixRatio) {
+    // Gemetric formula from http://en.wikipedia.org/wiki/Slerp
+
+    float sinTheta = length(cross(fromVector, toVector));
+    float theta = angle(fromVector, toVector);
+
+    float toPortion   = sin(theta * mixRatio) / sinTheta;
+    float fromPortion = sin(theta * (1.0 - mixRatio)) / sinTheta;
+
+    vec3 slerpVector = normalize(fromVector * fromPortion + toVector * toPortion);
+
+    // In situations where the vectors are nearly opposites, we sometimes get a
+    // negative z-value. In these cases the conjugate is just as valid, so we return
+    // that instead.
+    if (slerpVector[2] < 0.0) {
+        slerpVector[2] = -slerpVector[2];
+    }
+    return slerpVector;
+}
 
 void main() {
-    vec4 outputColor;
     vec4 baseColor = texture2D(inputImageTexture, textureCoordinate);
     vec4 overlayColor = texture2D(inputImageTexture2, textureCoordinate);
+    // overlayColor has anti-aliasing opacity which mixes it with black.
+    // For now we're just killing that with a floor.
+    float mixRatio = floor(overlayColor.a) * opacity;
 
-    outputColor = mix(baseColor, overlayColor, overlayColor.a*opacity);
+    if (mixRatio < epsilon) {
+        gl_FragColor = baseColor;
+    } else if (mixRatio > (1.0 - epsilon)) {
+        gl_FragColor = overlayColor;
+    } else {
+        vec3 baseNormal = colorToNormal(baseColor);
+        vec3 overlayNormal = colorToNormal(overlayColor);
+        vec3 outputNormal = slerp(baseNormal, overlayNormal, mixRatio);
 
-    gl_FragColor = outputColor;
+        gl_FragColor = normalToColor(outputNormal, baseColor.a);
+    }
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25293753%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295301%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295335%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295438%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295471%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23issuecomment-75852739%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25299853%22%2C%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23issuecomment-75969293%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23issuecomment-75852739%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20now%2C%20if%20you%20don%3Bt%20want%20to%20figure%20out%20the%20shared%20include%27s%20just%20copy%20and%20paste%20some%20header%20/%20the%20defines%20around%20to%20where%20they%20are%20needed.%20I%20attempted%20to%20figure%20out%20includes%20a%20while%20ago%20but%20gave%20up%20as%20it%20didn%27t%20work%20trivially.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A43%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Aship%3A%20%22%2C%20%22created_at%22%3A%20%222015-02-25T14%3A33%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f1599dbef905a8c6ce0f893649d99b9a9484f281%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295471%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Cross%20and%20dot%20are%20both%20built%20into%20the%20language.%20not%20sure%20abou%20tangle.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A41%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%3AL3-64%22%7D%2C%20%22Pull%20f1599dbef905a8c6ce0f893649d99b9a9484f281%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295335%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20pull%20this%20out%20to%20a%20separate%20function%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A40%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%3AL3-64%22%7D%2C%20%22Pull%20f1599dbef905a8c6ce0f893649d99b9a9484f281%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25293753%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20way%20to%20push%20off%20these%20function%20into%20another%20file%3F%20I%20couldn%27t%20find%20anything%2C%20but%20things%20like%20colorToNormal%20and%20NormalToColor%20would%20be%20good%20to%20reuse%20in%20multiple%20shaders.%20%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A22%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20there%20is%20a%20way.%20Basically%20you%20can%20%23include%20in%20glsl%20i%20think.%20Worst%20comes%20to%20worst%2C%20we%20can%20force%20gpuimage%20to%20append%20them%20before%20all%20of%20our%20filters%2C%20one%20shared%20header%20for%20example.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A39%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20mimicking%20the%20include%20structure/syntax%20of%20another%20git%20repo%2C%20and%20it%20didn%27t%20work.%20For%20now%2C%20I%27m%20just%20pulling%20everything%20out.%22%2C%20%22created_at%22%3A%20%222015-02-24T22%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2672344%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kotoole1%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%3AL3-64%22%7D%2C%20%22Pull%20f1599dbef905a8c6ce0f893649d99b9a9484f281%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/lukemetz/Paranormal/pull/70%23discussion_r25295438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20conversions%20should%20also%20be%20in%20a%20function.%20We%20have%20them%20already%20in%20I%20think%20depth%20to%20normal.%20EncodeNormal%20and%20Decode%20normal.%22%2C%20%22created_at%22%3A%20%222015-02-24T21%3A41%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1248454%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukemetz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh%3AL3-64%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f1599dbef905a8c6ce0f893649d99b9a9484f281 Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/70#discussion_r25293753'>File: Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh:L3-64</a></b>
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> Is there a way to push off these function into another file? I couldn't find anything, but things like colorToNormal and NormalToColor would be good to reuse in multiple shaders.
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> Yes there is a way. Basically you can #include in glsl i think. Worst comes to worst, we can force gpuimage to append them before all of our filters, one shared header for example.
- <a href='https://github.com/kotoole1'><img border=0 src='https://avatars.githubusercontent.com/u/2672344?v=3' height=16 width=16'></a> I tried mimicking the include structure/syntax of another git repo, and it didn't work. For now, I'm just pulling everything out.
- [ ] <a href='#crh-comment-Pull f1599dbef905a8c6ce0f893649d99b9a9484f281 Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/70#discussion_r25295335'>File: Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh:L3-64</a></b>
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> Please pull this out to a separate function
- [ ] <a href='#crh-comment-Pull f1599dbef905a8c6ce0f893649d99b9a9484f281 Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/70#discussion_r25295438'>File: Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh:L3-64</a></b>
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> These conversions should also be in a function. We have them already in I think depth to normal. EncodeNormal and Decode normal.
- [ ] <a href='#crh-comment-Pull f1599dbef905a8c6ce0f893649d99b9a9484f281 Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/70#discussion_r25295471'>File: Paranormal/Paranormal/GPUImageShaders/BlendAdd.fsh:L3-64</a></b>
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> Cross and dot are both built into the language. not sure abou tangle.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/lukemetz/Paranormal/pull/70#issuecomment-75852739'>General Comment</a></b>
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> For now, if you don;t want to figure out the shared include's just copy and paste some header / the defines around to where they are needed. I attempted to figure out includes a while ago but gave up as it didn't work trivially.
- <a href='https://github.com/lukemetz'><img border=0 src='https://avatars.githubusercontent.com/u/1248454?v=3' height=16 width=16'></a> :ship:

<a href='https://www.codereviewhub.com/lukemetz/Paranormal/pull/70?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/lukemetz/Paranormal/pull/70?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/lukemetz/Paranormal/pull/70'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
